### PR TITLE
Implement and export CpuId, MsrList and Msrs as FamStructWrappers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ kvm-v4_14_0 = []
 kvm-v4_20_0 = []
 
 [dependencies]
+vmm-sys-util = ">=0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ license = "Apache-2.0"
 [features]
 kvm-v4_14_0 = []
 kvm-v4_20_0 = []
+fam-wrappers = ["vmm-sys-util"]
 
 [dependencies]
-vmm-sys-util = ">=0.2.0"
+vmm-sys-util = { version = ">=0.2.0", optional = true }

--- a/README.md
+++ b/README.md
@@ -25,7 +25,20 @@ toml:
 ```toml
 kvm-bindings = { version = "0.1", features = ["kvm_v4_20_0"]}
 ```
-In the `kvm-bindings` crate each feature maps to exactly one Linux version
-as follows:
+Bindings are generated for each specific Linux kernel version based on the enabled
+crate features as follows:
 - `kvm_v4_14_0` contains the bindings for the Linux kernel version 4.14
 - `kvm_v4_20_0` contains the bindings for the Linux kernel version 4.20
+
+This crate also offers safe wrappers over FAM structs - FFI structs that have
+a Flexible Array Member in their definition.
+These safe wrappers can be used if the `fam-wrappers` feature is enabled for
+this crate. Example:
+```toml
+kvm-bindings = { version = "0.1", features = ["kvm_v4_20_0", "fam-wrappers"]}
+```
+
+# Dependencies
+The crate has an `optional` dependency to
+[vmm-sys-util](https://crates.io/crates/vmm-sys-util) when enabling the
+`fam-wrappers` feature.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,10 @@
 #![allow(non_snake_case)]
 
 #[macro_use]
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(all(
+    feature = "fam-wrappers",
+    any(target_arch = "x86", target_arch = "x86_64")
+))]
 extern crate vmm_sys_util;
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,10 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 
+#[macro_use]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+extern crate vmm_sys_util;
+
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod x86;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]

--- a/src/x86/fam_wrappers.rs
+++ b/src/x86/fam_wrappers.rs
@@ -57,3 +57,15 @@ generate_fam_struct_impl!(
 /// the array elements, this type is implemented using
 /// [FamStructWrapper](../vmm_sys_util/fam/struct.FamStructWrapper.html).
 pub type Msrs = FamStructWrapper<kvm_msrs>;
+
+// Implement the FamStruct trait for kvm_msr_list.
+generate_fam_struct_impl!(kvm_msr_list, u32, indices, u32, nmsrs, KVM_MAX_MSR_ENTRIES);
+
+/// Wrapper over the `kvm_msr_list` structure.
+///
+/// The `kvm_msr_list` structure contains a flexible array member. For details check the
+/// [KVM API](https://www.kernel.org/doc/Documentation/virtual/kvm/api.txt)
+/// documentation on `kvm_msr_list`. To provide safe access to
+/// the array elements, this type is implemented using
+/// [FamStructWrapper](../vmm_sys_util/fam/struct.FamStructWrapper.html).
+pub type MsrList = FamStructWrapper<kvm_msr_list>;

--- a/src/x86/fam_wrappers.rs
+++ b/src/x86/fam_wrappers.rs
@@ -17,6 +17,9 @@ use super::bindings_v4_20_0::*;
 /// See arch/x86/include/asm/kvm_host.h
 pub const KVM_MAX_CPUID_ENTRIES: usize = 80;
 
+/// Maximum number of MSRs KVM supports (See arch/x86/kvm/x86.c).
+pub const KVM_MAX_MSR_ENTRIES: usize = 256;
+
 // Implement the FamStruct trait for kvm_cpuid2.
 generate_fam_struct_impl!(
     kvm_cpuid2,
@@ -35,3 +38,22 @@ generate_fam_struct_impl!(
 /// the array elements, this type is implemented using
 /// [FamStructWrapper](../vmm_sys_util/fam/struct.FamStructWrapper.html).
 pub type CpuId = FamStructWrapper<kvm_cpuid2>;
+
+// Implement the FamStruct trait for kvm_msrs.
+generate_fam_struct_impl!(
+    kvm_msrs,
+    kvm_msr_entry,
+    entries,
+    u32,
+    nmsrs,
+    KVM_MAX_MSR_ENTRIES
+);
+
+/// Wrapper over the `kvm_msrs` structure.
+///
+/// The `kvm_msrs` structure contains a flexible array member. For details check the
+/// [KVM API](https://www.kernel.org/doc/Documentation/virtual/kvm/api.txt)
+/// documentation on `kvm_msrs`. To provide safe access to
+/// the array elements, this type is implemented using
+/// [FamStructWrapper](../vmm_sys_util/fam/struct.FamStructWrapper.html).
+pub type Msrs = FamStructWrapper<kvm_msrs>;

--- a/src/x86/fam_wrappers.rs
+++ b/src/x86/fam_wrappers.rs
@@ -1,0 +1,37 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use vmm_sys_util::fam::{FamStruct, FamStructWrapper};
+
+#[cfg(feature = "kvm-v4_14_0")]
+use super::bindings_v4_14_0::*;
+
+#[cfg(feature = "kvm-v4_20_0")]
+use super::bindings_v4_20_0::*;
+
+#[cfg(all(not(feature = "kvm-v4_14_0"), not(feature = "kvm-v4_20_0")))]
+use super::bindings_v4_20_0::*;
+
+/// Maximum number of CPUID entries that can be returned by a call to KVM ioctls.
+///
+/// See arch/x86/include/asm/kvm_host.h
+pub const KVM_MAX_CPUID_ENTRIES: usize = 80;
+
+// Implement the FamStruct trait for kvm_cpuid2.
+generate_fam_struct_impl!(
+    kvm_cpuid2,
+    kvm_cpuid_entry2,
+    entries,
+    u32,
+    nent,
+    KVM_MAX_CPUID_ENTRIES
+);
+
+/// Wrapper over the `kvm_cpuid2` structure.
+///
+/// The `kvm_cpuid2` structure contains a flexible array member. For details check the
+/// [KVM API](https://www.kernel.org/doc/Documentation/virtual/kvm/api.txt)
+/// documentation on `kvm_cpuid2`. To provide safe access to
+/// the array elements, this type is implemented using
+/// [FamStructWrapper](../vmm_sys_util/fam/struct.FamStructWrapper.html).
+pub type CpuId = FamStructWrapper<kvm_cpuid2>;

--- a/src/x86/mod.rs
+++ b/src/x86/mod.rs
@@ -1,6 +1,8 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+mod fam_wrappers;
+
 #[cfg(feature = "kvm-v4_14_0")]
 mod bindings_v4_14_0;
 #[cfg(feature = "kvm-v4_20_0")]
@@ -21,4 +23,6 @@ pub mod bindings {
 
     #[cfg(all(not(feature = "kvm-v4_14_0"), not(feature = "kvm-v4_20_0")))]
     pub use super::bindings_v4_20_0::*;
+
+    pub use super::fam_wrappers::*;
 }

--- a/src/x86/mod.rs
+++ b/src/x86/mod.rs
@@ -1,6 +1,7 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+#[cfg(feature = "fam-wrappers")]
 mod fam_wrappers;
 
 #[cfg(feature = "kvm-v4_14_0")]
@@ -24,5 +25,6 @@ pub mod bindings {
     #[cfg(all(not(feature = "kvm-v4_14_0"), not(feature = "kvm-v4_20_0")))]
     pub use super::bindings_v4_20_0::*;
 
+    #[cfg(feature = "fam-wrappers")]
     pub use super::fam_wrappers::*;
 }


### PR DESCRIPTION
# Description of changes

`kvm_cpuid2`, `kvm_msr_list` and `kvm_msrs` each contain a flexible array member and are forcing users of them to work with `unsafe` code.
Implement and export `CpuId`, `MsrList` and `Msrs` as safe wrappers over them.