### PR TITLE
Bump version to 0.1.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
+Cargo.lock
 .idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,23 @@
-# [0.1.0]
+# Changelog
+
+## [0.1.2]
+
+### Added
+
+- Added opt-in feature `fam-wrappers` that enables exporting
+  safe wrappers over generated structs with flexible array
+  members. This optional feature has an external dependency
+  on `vmm-sys-util`.
+- Added safe fam-wrappers for `kvm_msr_list`, `kvm_msrs`,
+  and `kvm_cpuid2`.
+
+## [0.1.1]
+
+### Changed
+
+- Do not enforce rust Edition 2018.
+
+## [0.1.0]
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,4 +1,0 @@
-[[package]]
-name = "kvm-bindings"
-version = "0.1.1"
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kvm-bindings"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Amazon firecracker team <firecracker-devel@amazon.com>"]
 description = "Rust FFI bindings to KVM generated using bindgen."
 repository = "https://github.com/rust-vmm/kvm-bindings"


### PR DESCRIPTION
Updated the `CHANGELOG` and also removed `Cargo.lock` from git tracking.