### PR TITLE
Switch to rust-vmm-ci

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,5 @@
+# This workaround is needed because the linker is unable to find __addtf3,
+# __multf3 and __subtf3.
+# Related issue: https://github.com/rust-lang/compiler-builtins/issues/201
+[target.aarch64-unknown-linux-musl]
+rustflags = [ "-C", "target-feature=+crt-static", "-C", "link-arg=-lgcc"]

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "rust-vmm-ci"]
+	path = rust-vmm-ci
+	url = https://github.com/rust-vmm/rust-vmm-ci.git

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,16 @@ cp arm/mod.rs arm64/
 
 Also, you will need to add the new architecture to `kvm-bindings/lib.rs`.
 
-# Future Improvements
+### Future Improvements
 All the above steps are scriptable, so in the next iteration I will add a
 script to generate the bindings.
+
+# Testing
+
+This crate is tested using
+[rust-vmm-ci](https://github.com/rust-vmm/rust-vmm-ci) and
+[Buildkite](https://buildkite.com/) pipelines. Each new feature added to this crate must be
+accompanied by Buildkite steps for testing the following:
+- Release builds (using musl/gnu) with the new feature on arm and x86
+- Coverage test as specified in the
+[rust-vmm-ci readme](https://github.com/rust-vmm/rust-vmm-ci#getting-started-with-rust-vmm-ci).

--- a/coverage_config.json
+++ b/coverage_config.json
@@ -1,0 +1,5 @@
+{
+  "coverage_score": 67.4,
+  "exclude_path": "",
+  "crate_features": "fam-wrappers"
+}

--- a/src/arm/mod.rs
+++ b/src/arm/mod.rs
@@ -1,24 +1,25 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-#[cfg(feature = "kvm-v4_14_0")]
+// Export 4.14 bindings when the feature kvm-v4_20_0 is not specified.
+#[cfg(all(feature = "kvm-v4_14_0", not(feature = "kvm-v4_20_0")))]
 mod bindings_v4_14_0;
-#[cfg(feature = "kvm-v4_20_0")]
-mod bindings_v4_20_0;
 
-// Major hack to have a default version in case no feature is specified:
-// If no version is specified by using the features, just use the latest one
-// which currently is 4.20.
-#[cfg(all(not(feature = "kvm-v4_14_0"), not(feature = "kvm-v4_20_0")))]
+// Export 4.20 bindings when kvm-v4_20_0 is specified or no kernel version
+// related features are specified.
+#[cfg(any(
+    feature = "kvm-v4_20_0",
+    all(not(feature = "kvm-v4_14_0"), not(feature = "kvm-v4_20_0"))
+))]
 mod bindings_v4_20_0;
 
 pub mod bindings {
-    #[cfg(feature = "kvm-v4_14_0")]
+    #[cfg(all(feature = "kvm-v4_14_0", not(feature = "kvm-v4_20_0")))]
     pub use super::bindings_v4_14_0::*;
 
-    #[cfg(feature = "kvm-v4_20_0")]
-    pub use super::bindings_v4_20_0::*;
-
-    #[cfg(all(not(feature = "kvm-v4_14_0"), not(feature = "kvm-v4_20_0")))]
+    #[cfg(any(
+        feature = "kvm-v4_20_0",
+        all(not(feature = "kvm-v4_14_0"), not(feature = "kvm-v4_20_0"))
+    ))]
     pub use super::bindings_v4_20_0::*;
 }

--- a/src/arm/mod.rs
+++ b/src/arm/mod.rs
@@ -3,6 +3,7 @@
 
 // Export 4.14 bindings when the feature kvm-v4_20_0 is not specified.
 #[cfg(all(feature = "kvm-v4_14_0", not(feature = "kvm-v4_20_0")))]
+#[allow(clippy::all)]
 mod bindings_v4_14_0;
 
 // Export 4.20 bindings when kvm-v4_20_0 is specified or no kernel version
@@ -11,6 +12,7 @@ mod bindings_v4_14_0;
     feature = "kvm-v4_20_0",
     all(not(feature = "kvm-v4_14_0"), not(feature = "kvm-v4_20_0"))
 ))]
+#[allow(clippy::all)]
 mod bindings_v4_20_0;
 
 pub mod bindings {

--- a/src/arm64/mod.rs
+++ b/src/arm64/mod.rs
@@ -1,24 +1,25 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-#[cfg(feature = "kvm-v4_14_0")]
+// Export 4.14 bindings when the feature kvm-v4_20_0 is not specified.
+#[cfg(all(feature = "kvm-v4_14_0", not(feature = "kvm-v4_20_0")))]
 mod bindings_v4_14_0;
-#[cfg(feature = "kvm-v4_20_0")]
-mod bindings_v4_20_0;
 
-// Major hack to have a default version in case no feature is specified:
-// If no version is specified by using the features, just use the latest one
-// which currently is 4.20.
-#[cfg(all(not(feature = "kvm-v4_14_0"), not(feature = "kvm-v4_20_0")))]
+// Export 4.20 bindings when kvm-v4_20_0 is specified or no kernel version
+// related features are specified.
+#[cfg(any(
+    feature = "kvm-v4_20_0",
+    all(not(feature = "kvm-v4_14_0"), not(feature = "kvm-v4_20_0"))
+))]
 mod bindings_v4_20_0;
 
 pub mod bindings {
-    #[cfg(feature = "kvm-v4_14_0")]
+    #[cfg(all(feature = "kvm-v4_14_0", not(feature = "kvm-v4_20_0")))]
     pub use super::bindings_v4_14_0::*;
 
-    #[cfg(feature = "kvm-v4_20_0")]
-    pub use super::bindings_v4_20_0::*;
-
-    #[cfg(all(not(feature = "kvm-v4_14_0"), not(feature = "kvm-v4_20_0")))]
+    #[cfg(any(
+        feature = "kvm-v4_20_0",
+        all(not(feature = "kvm-v4_14_0"), not(feature = "kvm-v4_20_0"))
+    ))]
     pub use super::bindings_v4_20_0::*;
 }

--- a/src/arm64/mod.rs
+++ b/src/arm64/mod.rs
@@ -3,6 +3,7 @@
 
 // Export 4.14 bindings when the feature kvm-v4_20_0 is not specified.
 #[cfg(all(feature = "kvm-v4_14_0", not(feature = "kvm-v4_20_0")))]
+#[allow(clippy::all)]
 mod bindings_v4_14_0;
 
 // Export 4.20 bindings when kvm-v4_20_0 is specified or no kernel version
@@ -11,6 +12,7 @@ mod bindings_v4_14_0;
     feature = "kvm-v4_20_0",
     all(not(feature = "kvm-v4_14_0"), not(feature = "kvm-v4_20_0"))
 ))]
+#[allow(clippy::all)]
 mod bindings_v4_20_0;
 
 pub mod bindings {

--- a/src/x86/fam_wrappers.rs
+++ b/src/x86/fam_wrappers.rs
@@ -3,14 +3,7 @@
 
 use vmm_sys_util::fam::{FamStruct, FamStructWrapper};
 
-#[cfg(feature = "kvm-v4_14_0")]
-use super::bindings_v4_14_0::*;
-
-#[cfg(feature = "kvm-v4_20_0")]
-use super::bindings_v4_20_0::*;
-
-#[cfg(all(not(feature = "kvm-v4_14_0"), not(feature = "kvm-v4_20_0")))]
-use super::bindings_v4_20_0::*;
+use x86::bindings::*;
 
 /// Maximum number of CPUID entries that can be returned by a call to KVM ioctls.
 ///

--- a/src/x86/mod.rs
+++ b/src/x86/mod.rs
@@ -4,25 +4,26 @@
 #[cfg(feature = "fam-wrappers")]
 mod fam_wrappers;
 
-#[cfg(feature = "kvm-v4_14_0")]
+// Export 4.14 bindings when the feature kvm-v4_20_0 is not specified.
+#[cfg(all(feature = "kvm-v4_14_0", not(feature = "kvm-v4_20_0")))]
 mod bindings_v4_14_0;
-#[cfg(feature = "kvm-v4_20_0")]
-mod bindings_v4_20_0;
 
-// Major hack to have a default version in case no feature is specified:
-// If no version is specified by using the features, just use the latest one
-// which currently is 4.20.
-#[cfg(all(not(feature = "kvm-v4_14_0"), not(feature = "kvm-v4_20_0")))]
+// Export 4.20 bindings when kvm-v4_20_0 is specified or no kernel version
+// related features are specified.
+#[cfg(any(
+    feature = "kvm-v4_20_0",
+    all(not(feature = "kvm-v4_14_0"), not(feature = "kvm-v4_20_0"))
+))]
 mod bindings_v4_20_0;
 
 pub mod bindings {
-    #[cfg(feature = "kvm-v4_14_0")]
+    #[cfg(all(feature = "kvm-v4_14_0", not(feature = "kvm-v4_20_0")))]
     pub use super::bindings_v4_14_0::*;
 
-    #[cfg(feature = "kvm-v4_20_0")]
-    pub use super::bindings_v4_20_0::*;
-
-    #[cfg(all(not(feature = "kvm-v4_14_0"), not(feature = "kvm-v4_20_0")))]
+    #[cfg(any(
+        feature = "kvm-v4_20_0",
+        all(not(feature = "kvm-v4_14_0"), not(feature = "kvm-v4_20_0"))
+    ))]
     pub use super::bindings_v4_20_0::*;
 
     #[cfg(feature = "fam-wrappers")]

--- a/src/x86/mod.rs
+++ b/src/x86/mod.rs
@@ -6,6 +6,7 @@ mod fam_wrappers;
 
 // Export 4.14 bindings when the feature kvm-v4_20_0 is not specified.
 #[cfg(all(feature = "kvm-v4_14_0", not(feature = "kvm-v4_20_0")))]
+#[allow(clippy::all)]
 mod bindings_v4_14_0;
 
 // Export 4.20 bindings when kvm-v4_20_0 is specified or no kernel version
@@ -14,6 +15,7 @@ mod bindings_v4_14_0;
     feature = "kvm-v4_20_0",
     all(not(feature = "kvm-v4_14_0"), not(feature = "kvm-v4_20_0"))
 ))]
+#[allow(clippy::all)]
 mod bindings_v4_20_0;
 
 pub mod bindings {


### PR DESCRIPTION
Use Buildkite and rust-vmm-ci for testing.

For a successful build, a few other changes were required:
- Fix the aarch64 musl build
- Make the bindings features mutually exclusive. This is needed because the Buildkite pipeline uses `cargo test --all-features` as a step.
- Disable clippy because for autogenerated code we get a lot of errors and we would need to add manual changes to the auto-generated code.