### PR TITLE
arm: add wrapper over `kvm_reg_list`

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -35,6 +35,8 @@ steps:
 
   - label: "build-v4.14-arm"
     commands:
+      - cargo build --release --features=fam-wrappers,kvm-v4_14_0
+      - cargo build --release --features=fam-wrappers,kvm-v4_14_0 --target aarch64-unknown-linux-musl
       - cargo build --release --features=kvm-v4_14_0
       - cargo build --release --features=kvm-v4_14_0 --target aarch64-unknown-linux-musl
     retry:

--- a/src/arm/fam_wrappers.rs
+++ b/src/arm/fam_wrappers.rs
@@ -1,0 +1,22 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use vmm_sys_util::fam::{FamStruct, FamStructWrapper};
+
+use arm::bindings::*;
+
+// There is no constant in the kernel as far as the maximum number
+// of registers on arm, but KVM_GET_REG_LIST usually returns around 450.
+const ARM_REGS_MAX: usize = 500;
+
+// Implement the FamStruct trait for kvm_reg_list.
+generate_fam_struct_impl!(kvm_reg_list, u64, reg, u64, n, ARM_REGS_MAX);
+
+/// Wrapper over the `kvm_reg_list` structure.
+///
+/// The `kvm_reg_list` structure contains a flexible array member. For details check the
+/// [KVM API](https://www.kernel.org/doc/Documentation/virtual/kvm/api.txt)
+/// documentation on `kvm_reg_list`. To provide safe access to
+/// the array elements, this type is implemented using
+/// [FamStructWrapper](../vmm_sys_util/fam/struct.FamStructWrapper.html).
+pub type RegList = FamStructWrapper<kvm_reg_list>;

--- a/src/arm/mod.rs
+++ b/src/arm/mod.rs
@@ -1,6 +1,9 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+#[cfg(feature = "fam-wrappers")]
+mod fam_wrappers;
+
 // Export 4.14 bindings when the feature kvm-v4_20_0 is not specified.
 #[cfg(all(feature = "kvm-v4_14_0", not(feature = "kvm-v4_20_0")))]
 #[allow(clippy::all)]
@@ -24,4 +27,7 @@ pub mod bindings {
         all(not(feature = "kvm-v4_14_0"), not(feature = "kvm-v4_20_0"))
     ))]
     pub use super::bindings_v4_20_0::*;
+
+    #[cfg(feature = "fam-wrappers")]
+    pub use super::fam_wrappers::*;
 }

--- a/src/arm64/fam_wrappers.rs
+++ b/src/arm64/fam_wrappers.rs
@@ -1,0 +1,22 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use vmm_sys_util::fam::{FamStruct, FamStructWrapper};
+
+use arm64::bindings::*;
+
+// There is no constant in the kernel as far as the maximum number
+// of registers on arm, but KVM_GET_REG_LIST usually returns around 450.
+const ARM64_REGS_MAX: usize = 500;
+
+// Implement the FamStruct trait for kvm_reg_list.
+generate_fam_struct_impl!(kvm_reg_list, u64, reg, u64, n, ARM64_REGS_MAX);
+
+/// Wrapper over the `kvm_reg_list` structure.
+///
+/// The `kvm_reg_list` structure contains a flexible array member. For details check the
+/// [KVM API](https://www.kernel.org/doc/Documentation/virtual/kvm/api.txt)
+/// documentation on `kvm_reg_list`. To provide safe access to
+/// the array elements, this type is implemented using
+/// [FamStructWrapper](../vmm_sys_util/fam/struct.FamStructWrapper.html).
+pub type RegList = FamStructWrapper<kvm_reg_list>;

--- a/src/arm64/mod.rs
+++ b/src/arm64/mod.rs
@@ -1,6 +1,9 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+#[cfg(feature = "fam-wrappers")]
+mod fam_wrappers;
+
 // Export 4.14 bindings when the feature kvm-v4_20_0 is not specified.
 #[cfg(all(feature = "kvm-v4_14_0", not(feature = "kvm-v4_20_0")))]
 #[allow(clippy::all)]
@@ -24,4 +27,7 @@ pub mod bindings {
         all(not(feature = "kvm-v4_14_0"), not(feature = "kvm-v4_20_0"))
     ))]
     pub use super::bindings_v4_20_0::*;
+
+    #[cfg(feature = "fam-wrappers")]
+    pub use super::fam_wrappers::*;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,10 +6,7 @@
 #![allow(non_snake_case)]
 
 #[macro_use]
-#[cfg(all(
-    feature = "fam-wrappers",
-    any(target_arch = "x86", target_arch = "x86_64")
-))]
+#[cfg(feature = "fam-wrappers")]
 extern crate vmm_sys_util;
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]


### PR DESCRIPTION
In order to be able to save/restore vcpu registers
on arm, we need to support the KVM_REG_LIST
ioctl. However, the structure holding the registers
list has a flexible array member.
This commit add a `FamStructWrapper` over the `kvm_reg_list`
structure.

Fixes #20 