### PR TITLE
Release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.3.1]
+
+### Changed
+
+- Enforced the `vmm-sys-util` dependency to v0.7.0.
+
 ## [0.3.0]
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ kvm-v4_20_0 = []
 fam-wrappers = ["vmm-sys-util"]
 
 [dependencies]
-vmm-sys-util = { version = ">=0.2.0", optional = true }
+vmm-sys-util = { version = "=0.7.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kvm-bindings"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Amazon firecracker team <firecracker-devel@amazon.com>"]
 description = "Rust FFI bindings to KVM generated using bindgen."
 repository = "https://github.com/rust-vmm/kvm-bindings"


### PR DESCRIPTION
This release forces the `vmm-sys-utility` dependency to version 0.7.0, for compatibility with the upcoming `kvm-ioctls` v0.6.1 release. See also: https://github.com/rust-vmm/kvm-ioctls/issues/141#issuecomment-790429359