### PR TITLE
Release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.4.0]
+
+- vmm-sys-utils dependency bumped to match kvm-ioctls
+
 ## [0.3.0]
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kvm-bindings"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Amazon firecracker team <firecracker-devel@amazon.com>"]
 description = "Rust FFI bindings to KVM generated using bindgen."
 repository = "https://github.com/rust-vmm/kvm-bindings"
@@ -14,4 +14,4 @@ kvm-v4_20_0 = []
 fam-wrappers = ["vmm-sys-util"]
 
 [dependencies]
-vmm-sys-util = { version = ">=0.2.0", optional = true }
+vmm-sys-util = { version = ">=0.8.0", optional = true }


### PR DESCRIPTION
This release is to allow kvm-ioctls to be released with an increased
dependency on kvm-bindings rather than pinning to an older version.
Update the vmm-sys-utils version to reflect the latest version and to
match the one from kvm-ioctls.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>