### PR TITLE
x86: enlarge KVM_MAX_CPUID_ENTRIES to 256

### DIFF
--- a/src/x86/fam_wrappers.rs
+++ b/src/x86/fam_wrappers.rs
@@ -8,7 +8,7 @@ use x86::bindings::*;
 /// Maximum number of CPUID entries that can be returned by a call to KVM ioctls.
 ///
 /// See arch/x86/include/asm/kvm_host.h
-pub const KVM_MAX_CPUID_ENTRIES: usize = 80;
+pub const KVM_MAX_CPUID_ENTRIES: usize = 256;
 
 /// Maximum number of MSRs KVM supports (See arch/x86/kvm/x86.c).
 pub const KVM_MAX_MSR_ENTRIES: usize = 256;


### PR DESCRIPTION
Since kernel commit "3f4e3eb4 KVM: x86: bump KVM_MAX_CPUID_ENTRIES",
the KVM_MAX_CPUID_ENTRIES in linux kernel has been changed from 80 to
256. So change KVM_MAX_CPUID_ENTRIES to 256 too, it should also work
with kernel prior to 5.9.

Signed-off-by: Liu Jiang <gerry@linux.alibaba.com>