### PR TITLE
Fix warnings and adjust test coverage

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 67.5,
+  "coverage_score": 68.3,
   "exclude_path": "",
   "crate_features": "fam-wrappers"
 }

--- a/src/arm64/mod.rs
+++ b/src/arm64/mod.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #[allow(clippy::all)]
+// Keep this until https://github.com/rust-lang/rust-bindgen/issues/1651 is fixed.
+#[cfg_attr(test, allow(deref_nullptr))]
 pub mod bindings;
 #[cfg(feature = "fam-wrappers")]
 pub mod fam_wrappers;

--- a/src/x86/mod.rs
+++ b/src/x86/mod.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #[allow(clippy::all)]
+// Keep this until https://github.com/rust-lang/rust-bindgen/issues/1651 is fixed.
+#[cfg_attr(test, allow(deref_nullptr))]
 pub mod bindings;
 #[cfg(feature = "fam-wrappers")]
 pub mod fam_wrappers;


### PR DESCRIPTION
This PR includes the original one from dependabot #64 
It fixes clippy warnings and test coverage due to updated Rust version.