### PR TITLE
src/x86/ does not support 32bit x86

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,7 @@
 Rust FFI bindings to KVM, generated using
 [bindgen](https://crates.io/crates/bindgen). It currently has support for the
 following target architectures:
-- x86
 - x86_64
-- arm
 - arm64
 
 The bindings exported by this crate are statically generated using header files

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,9 +11,9 @@
 #[cfg(feature = "fam-wrappers")]
 extern crate vmm_sys_util;
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(any(target_arch = "x86_64"))]
 mod x86;
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(any(target_arch = "x86_64"))]
 pub use self::x86::*;
 
 #[cfg(any(target_arch = "aarch", target_arch = "aarch64"))]


### PR DESCRIPTION
src/x86/ does not support i386 or x32:
https://buildd.debian.org/status/fetch.php?pkg=rust-kvm-bindings&arch=i386&ver=0.5.0-1&stamp=1664239343&raw=0
https://buildd.debian.org/status/fetch.php?pkg=rust-kvm-bindings&arch=x32&ver=0.5.0-1&stamp=1664711616&raw=0