### PR TITLE
versions: update vmm-sys-util version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ license = "Apache-2.0"
 fam-wrappers = ["vmm-sys-util"]
 
 [dependencies]
-vmm-sys-util = { version = ">=0.8.0", optional = true }
+vmm-sys-util = { version = "0.11.0", optional = true }


### PR DESCRIPTION
In order to use caret dependency, we should specify vmm-sys-util dependency to the latest version (0.11.0)

fixes: #74

Signed-off-by: Chao Wu <chaowu@linux.alibaba.com>

### Summary of the PR

#74 

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] Any newly added `unsafe` code is properly documented.
