### PR TITLE
Build docs.rs documentation with all features enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - The x86 module has been renamed to x86_64 for consistency (matches the kernel
   architecture directory name)
 - Dropped "x86" (32-bit) x86 support
+- Added all features to the generated docs.rs documentation.
 
 ## [0.6.0]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,10 @@ readme = "README.md"
 keywords = ["kvm"]
 license = "Apache-2.0"
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [features]
 fam-wrappers = ["vmm-sys-util"]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 #[macro_use]
 #[cfg(feature = "fam-wrappers")]


### PR DESCRIPTION
### Summary of the PR

The current documentation build in docs.rs does not include any crate features (at the moment just `fam-wrappers`), which might lead to users of the crate not being aware of their existence.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [X] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- `N/A` All added/changed functionality has a corresponding unit/integration
  test.
- [X] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- `N/A` Any newly added `unsafe` code is properly documented.
