### PR TITLE
Update vmm-sys-util to 0.12.1 and prepare release 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,18 @@
 # Changelog
 ## [Unreleased]
 
+## [0.7.0]
+
+### Changed
 - API change in the bindings from upstream kernel changes:
-* system_event has been made into a new union
-- The x86 module has been renamed to x86_64 for consistency (matches the kernel
+  * system\_event has been made into a new union
+- The x86 module has been renamed to x86\_64 for consistency (matches the kernel
   architecture directory name)
-- Dropped "x86" (32-bit) x86 support
 - Added all features to the generated docs.rs documentation.
+
+### Removed
+
+- Dropped "x86" (32-bit) x86 support
 
 ## [0.6.0]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ rustdoc-args = ["--cfg", "docsrs"]
 fam-wrappers = ["vmm-sys-util"]
 
 [dependencies]
-vmm-sys-util = { version = "0.11.0", optional = true }
+vmm-sys-util = { version = "0.12.1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kvm-bindings"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Amazon firecracker team <firecracker-devel@amazon.com>"]
 description = "Rust FFI bindings to KVM generated using bindgen."
 repository = "https://github.com/rust-vmm/kvm-bindings"

--- a/src/x86_64/fam_wrappers.rs
+++ b/src/x86_64/fam_wrappers.rs
@@ -120,10 +120,15 @@ mod tests {
 
         let mut wrapper2 = wrapper.clone();
         assert!(wrapper == wrapper2);
-
-        wrapper.as_mut_fam_struct().pad = 1;
+        // SAFETY: We are not modifying the `nmsrs` field
+        unsafe {
+            wrapper.as_mut_fam_struct().pad = 1;
+        }
         assert!(wrapper != wrapper2);
-        wrapper2.as_mut_fam_struct().pad = 1;
+        // SAFETY: We are not modifying the `nmsrs` field
+        unsafe {
+            wrapper2.as_mut_fam_struct().pad = 1;
+        }
         assert!(wrapper == wrapper2);
 
         wrapper.as_mut_slice()[1].data = 1;


### PR DESCRIPTION
### Summary of the PR

The vmm-sys-util version bump was needed due to https://github.com/rust-vmm/vmm-sys-util/security/advisories/GHSA-875g-mfp6-g7f9. kvm-bindings is not affected though because it does not use the `with-serde` feature flag. 

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
