### PR TITLE
Remove unnecessary clippy override

### DIFF
--- a/src/arm64/mod.rs
+++ b/src/arm64/mod.rs
@@ -3,8 +3,6 @@
 
 #[allow(clippy::all)]
 #[allow(clippy::undocumented_unsafe_blocks)]
-// Keep this until https://github.com/rust-lang/rust-bindgen/issues/1651 is fixed.
-#[cfg_attr(test, allow(deref_nullptr))]
 pub mod bindings;
 #[cfg(feature = "fam-wrappers")]
 pub mod fam_wrappers;

--- a/src/x86_64/mod.rs
+++ b/src/x86_64/mod.rs
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 #[allow(clippy::undocumented_unsafe_blocks)]
 #[allow(clippy::all)]
-// Keep this until https://github.com/rust-lang/rust-bindgen/issues/1651 is fixed.
-#[cfg_attr(test, allow(deref_nullptr))]
 pub mod bindings;
 #[cfg(feature = "fam-wrappers")]
 pub mod fam_wrappers;


### PR DESCRIPTION
The clippy override `allow(deref_nullptr)` is no longer needed since the issue has been fixed from rust-bindgen [1].

[1] https://github.com/rust-lang/rust-bindgen/issues/1651

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
