### PR TITLE
fix: Implement `Default` for `kvm_xsave2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@
 
 ### Removed
 
+## [0.8.1]
+
+### Fixed
+
+- Implement `Default` for `kvm_xsave2`, which fixes usage of `Xsave`
+  unconditionally causing compile errors in downstream crates.
+
 ## [0.8.0]
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kvm-bindings"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Amazon firecracker team <firecracker-devel@amazon.com>"]
 description = "Rust FFI bindings to KVM generated using bindgen."
 repository = "https://github.com/rust-vmm/kvm-bindings"

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 64,
+  "coverage_score": 80.77,
   "exclude_path": ".*bindings\\.rs",
   "crate_features": "fam-wrappers,serde"
 }

--- a/src/x86_64/fam_wrappers.rs
+++ b/src/x86_64/fam_wrappers.rs
@@ -98,6 +98,7 @@ pub type MsrList = FamStructWrapper<kvm_msr_list>;
 ///
 /// See also: [`Xsave`].
 #[repr(C)]
+#[derive(Debug, Default)]
 pub struct kvm_xsave2 {
     pub len: usize,
     pub xsave: kvm_xsave,

--- a/src/x86_64/fam_wrappers.rs
+++ b/src/x86_64/fam_wrappers.rs
@@ -160,8 +160,10 @@ pub type Xsave = FamStructWrapper<kvm_xsave2>;
 
 #[cfg(test)]
 mod tests {
-    use super::{CpuId, MsrList, Msrs};
+    use super::{CpuId, MsrList, Msrs, Xsave};
     use x86_64::bindings::kvm_cpuid_entry2;
+
+    use vmm_sys_util::fam::FamStruct;
 
     #[test]
     fn test_cpuid_eq() {
@@ -214,5 +216,12 @@ mod tests {
         assert!(wrapper != wrapper2);
         wrapper2.as_mut_slice()[0] = 1;
         assert!(wrapper == wrapper2);
+    }
+    #[test]
+    fn test_xsave() {
+        let wrapper = Xsave::new(1).unwrap();
+        assert_eq!(wrapper.as_slice().len(), 1);
+        assert_eq!(wrapper.as_fam_struct_ref().len(), 1);
+        assert_eq!(wrapper.as_fam_struct_ref().len, 1);
     }
 }

--- a/src/x86_64/fam_wrappers.rs
+++ b/src/x86_64/fam_wrappers.rs
@@ -100,6 +100,11 @@ pub type MsrList = FamStructWrapper<kvm_msr_list>;
 #[repr(C)]
 #[derive(Debug, Default)]
 pub struct kvm_xsave2 {
+    /// The length, in bytes, of the FAM in [`kvm_xsave`].
+    ///
+    /// Note that `KVM_CHECK_EXTENSION(KVM_CAP_XSAVE2)` returns the size of the entire
+    /// `kvm_xsave` structure, e.g. the sum of header and FAM. Thus, this `len` field
+    /// is equal to `KVM_CHECK_EXTENSION(KVM_CAP_XSAVE2) - 4096`.
     pub len: usize,
     pub xsave: kvm_xsave,
 }


### PR DESCRIPTION
### Summary of the PR

Implement `Default` for `kvm_xsave2`. This is a requirement for `FamStructWrapper<kvm_xsave2>` to be used. This was missed because apparently defining the type alias `pub type Xsave = FamStructWrapper<kvm_xsave2>` does not cause compilation errors despite `kvm_xsave2` not implementing `Default`. However, when `Xsave` is being used in downstream crates, they will see errors like

```
   Compiling kvm-ioctls v0.17.0 (/home/ANT.AMAZON.COM/roypat/Development/rust-vmm/kvm-ioctls)
error[E0277]: the trait bound `kvm_xsave2: Default` is not satisfied
   --> src/ioctls/vcpu.rs:858:54
    |
858 |     pub fn get_xsave2(&self, vm_fd: &VmFd) -> Result<Xsave> {
    |                                                      ^^^^^ the trait `Default` is not implemented for `kvm_xsave2`
    |
note: required by a bound in `FamStructWrapper`
   --> /home/ANT.AMAZON.COM/roypat/.cargo/registry/src/index.crates.io-6f17d22bba15001f/vmm-sys-util-0.12.1/src/fam.rs:164:32
    |
164 | pub struct FamStructWrapper<T: Default + FamStruct> {
    |                                ^^^^^^^ required by this bound in `FamStructWrapper`

For more information about this error, try `rustc --explain E0277`.
error: could not compile `kvm-ioctls` (lib) due to 1 previous error
```

Fix this, and do a 0.8.1 release with the fix.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
