### PR TITLE
fix: Avoid temporary `Vec<u8>` allocation during deserialization

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 80.77,
+  "coverage_score": 78.57,
   "exclude_path": ".*bindings\\.rs",
   "crate_features": "fam-wrappers,serde"
 }


### PR DESCRIPTION
Instead of reusing `Vec::<u8>::deserialize` to defer the deserialization, implement a Visitor that can construct `$typ` directly from the deserialization byte stream. This eliminates a temporary allocation where the input byte stream is first copied into a `Vec<u8>` and later copied to the stack to construct `$typ` via `transmute!`.

This saves a few microseconds (up to 1ms on specific hardware) when deserializing microVM snapshots.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
