### PR TITLE
Fix and validate manual (De)Serialize implementations with serde_json

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,4 @@ zerocopy = { version = "0.7.32", optional = true, features = ["derive"] }
 
 [dev-dependencies]
 bincode = "1.3.3"
+serde_json = "1.0.125"

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 78.57,
+  "coverage_score": 81.25,
   "exclude_path": ".*bindings\\.rs",
   "crate_features": "fam-wrappers,serde"
 }

--- a/src/arm64/serialize.rs
+++ b/src/arm64/serialize.rs
@@ -57,4 +57,23 @@ mod tests {
         is_serde::<kvm_mp_state>();
         is_serde::<kvm_one_reg>();
     }
+
+    fn is_serde_json<T: Serialize + for<'de> Deserialize<'de> + Default>() {
+        let serialized = serde_json::to_string(&T::default()).unwrap();
+        let deserialized = serde_json::from_str::<T>(serialized.as_ref()).unwrap();
+        let serialized_again = serde_json::to_string(&deserialized).unwrap();
+        // Compare the serialized state after a roundtrip, to work around issues with
+        // bindings not implementing `PartialEq`.
+        assert_eq!(serialized, serialized_again);
+    }
+
+    #[test]
+    fn test_json_serde() {
+        is_serde_json::<user_pt_regs>();
+        is_serde_json::<user_fpsimd_state>();
+        is_serde_json::<kvm_regs>();
+        is_serde_json::<kvm_vcpu_init>();
+        is_serde_json::<kvm_mp_state>();
+        is_serde_json::<kvm_one_reg>();
+    }
 }

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -42,6 +42,18 @@ macro_rules! serde_impls {
                             backing[..limit].copy_from_slice(&bytes[..limit]);
                             Ok(backing)
                         }
+
+                        fn visit_seq<A: serde::de::SeqAccess<'a>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
+                            let mut backing = [0u8; std::mem::size_of::<$typ>()];
+
+                            for backing_byte in &mut backing {
+                                let Some(byte) = seq.next_element()? else { break };
+
+                                *backing_byte = byte;
+                            }
+
+                            Ok(backing)
+                        }
                     }
 
                     let backing = deserializer.deserialize_bytes(BytesVisitor)?;

--- a/src/x86_64/serialize.rs
+++ b/src/x86_64/serialize.rs
@@ -123,4 +123,34 @@ mod tests {
         is_serde::<kvm_irqchip>();
         is_serde::<kvm_mp_state>();
     }
+
+    fn is_serde_json<T: Serialize + for<'de> Deserialize<'de> + Default>() {
+        let serialized = serde_json::to_string(&T::default()).unwrap();
+        let deserialized = serde_json::from_str::<T>(serialized.as_ref()).unwrap();
+        let serialized_again = serde_json::to_string(&deserialized).unwrap();
+        // Compare the serialized state after a roundtrip, to work around issues with
+        // bindings not implementing `PartialEq`.
+        assert_eq!(serialized, serialized_again);
+    }
+
+    #[test]
+    fn test_json_serde() {
+        is_serde_json::<kvm_clock_data>();
+        is_serde_json::<kvm_regs>();
+        is_serde_json::<kvm_segment>();
+        is_serde_json::<kvm_dtable>();
+        is_serde_json::<kvm_sregs>();
+        is_serde_json::<kvm_msr_entry>();
+        is_serde_json::<kvm_msrs>();
+        is_serde_json::<kvm_cpuid_entry2>();
+        is_serde_json::<kvm_cpuid2>();
+        is_serde_json::<kvm_pit_channel_state>();
+        is_serde_json::<kvm_pit_state2>();
+        is_serde_json::<kvm_vcpu_events>();
+        is_serde_json::<kvm_debugregs>();
+        is_serde_json::<kvm_xcr>();
+        is_serde_json::<kvm_xcrs>();
+        is_serde_json::<kvm_irqchip>();
+        is_serde_json::<kvm_mp_state>();
+    }
 }


### PR DESCRIPTION
### Summary of the PR

The 'serde_json' crate has been commonly used to (de)serialize Rust data structures in the format of JSON, such as Cloud Hyervisor uses this crate for its live migration support. This patch adds a set of unit tests to ensure our manual (De)Serialize implementations works with the 'serde_json' crate.

The new Deserializer implementation (https://github.com/rust-vmm/kvm-bindings/pull/107) does not work with the 'serde_json' crate, particularly `serde_json::{to_string, from_str}`. The new implementation always expects `byte array` for deserilaiztion. Meanwhile, the 'serde_json' crate always (de)serializes `String` as `Vector` [1][2] which is treated as `sequence` (e.g. not 'byte array') by default for (de)serialization [3].

Reverting #107 seems to be the simplest solution to fix this issue. Suggestions are welcome.

[1] https://github.com/serde-rs/json/blob/cc7a1608c9bb7736c884926e016421af41a1ebe7/src/ser.rs#L2168-L2175
[2] https://github.com/serde-rs/json/blob/cc7a1608c9bb7736c884926e016421af41a1ebe7/src/de.rs#L30-L39
[3] https://serde.rs/data-model.html#types

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
